### PR TITLE
Replace FortiGuard & color.a11y.com with categorify.org + pa11y

### DIFF
--- a/.github/workflows/nightly-scan.yml
+++ b/.github/workflows/nightly-scan.yml
@@ -32,8 +32,8 @@ jobs:
           pip install --upgrade pip
           pip install -r scripts/requirements.txt
 
-      - name: Install Playwright browser
-        run: playwright install --with-deps chromium
+      - name: Install pa11y
+        run: npm install -g pa11y
 
       - name: Create output directories
         run: |

--- a/scripts/core_functions.py
+++ b/scripts/core_functions.py
@@ -38,41 +38,43 @@ def get_categorify_category(domain):
         return "Unknown"
 
 
-def check_contrast(browser, t_url):
-    """Check colour contrast for the given domain using an existing Playwright browser."""
-    page = browser.new_page()
+def check_contrast(url):
+    """Check colour contrast and accessibility for the given URL using pa11y.
+
+    Returns 'PASS' if no WCAG2AA errors are found, 'FAIL' if errors exist,
+    or -1 on a technical failure (pa11y crash / timeout).
+    """
     try:
-        _log(f"  [check_contrast] Checking contrast for {t_url}")
-        page.goto("https://color.a11y.com/Contrast/", timeout=30000)
-        page.fill('[name="urltotest"]', t_url)
-        page.click('[name="submitbutton"]')
+        _log(f"  [check_contrast] Running pa11y for {url}")
+        result = core_modules.subprocess.run(
+            [
+                "pa11y",
+                "--reporter", "json",
+                "--standard", "WCAG2AA",
+                "--chromium-flag", "--no-sandbox",
+                "--chromium-flag", "--disable-setuid-sandbox",
+                url,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        # pa11y exit codes: 0 = clean, 1 = issues found, 2 = technical error
+        if result.returncode == 2:
+            _log(f"  [check_contrast] pa11y technical error for {url}: {result.stderr.strip()}")
+            return -1
 
-        # Wait for results to appear
-        try:
-            page.wait_for_selector(".congratsbox, .nocongratsbox", timeout=20000)
-            _log(f"  [check_contrast] Result selector found for {t_url}")
-        except core_modules.PlaywrightTimeoutError:
-            _log(f"  [check_contrast] Result selector NOT found within 20s for {t_url} – proceeding anyway")
+        issues = core_modules.json.loads(result.stdout) if result.stdout.strip() else []
+        errors = [i for i in issues if i.get("type") == "error"]
+        _log(f"  [check_contrast] {url}: {len(errors)} WCAG2AA error(s) ({len(issues)} total issue(s))")
+        return "FAIL" if errors else "PASS"
 
-        page_content = page.inner_html("body")
-        soup = core_modules.BeautifulSoup(page_content, "html.parser")
-        failed = soup.find_all("div", class_="nocongratsbox")
-        passed = soup.find_all("div", class_="congratsbox")
-
-        _log(f"  [check_contrast] {t_url}: passed={len(passed)}, failed={len(failed)}")
-
-        if len(failed) > 0:
-            return "FAIL"
-        if len(passed) > 0:
-            return "PASS"
-
-    except Exception as e:
-        _log(f"  [check_contrast] Error checking contrast for {t_url}: {e}")
+    except core_modules.subprocess.TimeoutExpired:
+        _log(f"  [check_contrast] pa11y timed out for {url}")
         return -1
-    finally:
-        page.close()
-
-    return 0
+    except Exception as e:
+        _log(f"  [check_contrast] Error checking accessibility for {url}: {e}")
+        return -1
 
 
 def fetch_urls_from_tranco(limit=500):

--- a/scripts/core_modules.py
+++ b/scripts/core_modules.py
@@ -5,10 +5,9 @@ import datetime
 import requests
 import os
 import json
+import subprocess
 import validators
-from bs4 import BeautifulSoup
 from urllib.parse import urlparse
-from playwright.sync_api import sync_playwright, TimeoutError as PlaywrightTimeoutError
 import concurrent.futures
 import io
 import zipfile

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,11 +1,6 @@
-beautifulsoup4==4.12.2
-bs4==0.0.1
 certifi==2023.11.17
 charset-normalizer==3.3.2
 idna==3.6
-lxml==4.9.3
-playwright==1.50.0
 requests==2.31.0
-soupsieve==2.5
 urllib3==1.26.18
 validators==0.22.0

--- a/scripts/scanner.py
+++ b/scripts/scanner.py
@@ -121,13 +121,8 @@ def process_domain(url):
         log(f"[{domain}] Category '{site_cats}' is banned – skipping")
         return
 
-    with core_modules.sync_playwright() as p:
-        browser = p.chromium.launch(headless=True)
-        try:
-            log(f"[{domain}] Running contrast check...")
-            contrast = core_functions.check_contrast(browser, domain)
-        finally:
-            browser.close()
+    log(f"[{domain}] Running contrast check...")
+    contrast = core_functions.check_contrast(url)
 
     if contrast == 0:
         log(f"[{domain}] Contrast check result: BLOCKED (no result from checker)")


### PR DESCRIPTION
## What changed

Both external checkers in the nightly scanner were broken:

- **FortiGuard** was returning `Unknown` for every domain due to captcha/JS blocking
- **color.a11y.com** was timing out on `Page.fill` for every domain

### URL categorisation → categorify.org

Replaced the Playwright-based FortiGuard scraper with a plain HTTP GET to the [categorify.org API](https://categorify.org/api?website=google.com). No browser needed; returns structured JSON with a `category` array.

### Contrast/accessibility check → pa11y CLI

Replaced the color.a11y.com Playwright scraper with [pa11y](https://pa11y.org) running locally in the workflow. pa11y performs WCAG2AA checks against the full URL and returns structured JSON — no external service, no captcha risk.

### Knock-on cleanup

Since neither check needs Playwright or BeautifulSoup any more, both have been removed:

- `requirements.txt` — dropped `playwright`, `beautifulsoup4`, `bs4`, `lxml`, `soupsieve`
- `core_modules.py` — removed Playwright and BeautifulSoup imports
- `nightly-scan.yml` — swapped `playwright install --with-deps chromium` for `npm install -g pa11y`

## Files changed

| File | Change |
|---|---|
| `scripts/core_functions.py` | New `get_categorify_category()`, new `check_contrast()` via pa11y |
| `scripts/scanner.py` | Call categorify before Playwright block; drop Playwright block; pass full URL to contrast check |
| `scripts/core_modules.py` | Remove BS4 + Playwright imports; add `subprocess` |
| `scripts/requirements.txt` | Remove 5 now-unused packages |
| `.github/workflows/nightly-scan.yml` | Replace Playwright install with pa11y install |