### PR TITLE
Switch URL categorisation to sitecategory.com; cap URLs at 100

### DIFF
--- a/scripts/core_functions.py
+++ b/scripts/core_functions.py
@@ -1,40 +1,63 @@
 import core_modules
 
-CATEGORIFY_API_URL = "https://categorify.org/api"
+SITECATEGORY_SESSION_URL = "https://api.sitecategory.com/api/session"
+SITECATEGORY_CATEGORIZE_URL = "https://api.sitecategory.com/api/categorize"
 
 
 def _log(msg):
     print(msg, flush=True)
 
 
-def get_categorify_category(domain):
-    """Get the URL category for a domain using the categorify.org API.
+def get_sitecategory_token():
+    """Obtain a session token from the sitecategory.com API.
 
-    Returns a comma-separated category string (e.g. 'Search Engine, Clean Browsing')
-    or 'Unknown' if the category cannot be determined.  Never raises; all errors are
-    handled internally so callers can always expect a string back.
+    Returns the token string, or None on failure.
     """
     try:
-        _log(f"  [get_categorify_category] Looking up category for {domain}")
-        response = core_modules.requests.get(
-            CATEGORIFY_API_URL,
-            params={"website": domain},
+        response = core_modules.requests.post(
+            SITECATEGORY_SESSION_URL,
+            headers={"Content-Type": "application/json"},
             timeout=15,
         )
-        if response.status_code == 400:
-            _log(f"  [get_categorify_category] Invalid domain or unprocessable: {domain} – using 'Unknown'")
-            return "Unknown"
+        response.raise_for_status()
+        token = response.json().get("token")
+        _log(f"[sitecategory] Session token obtained")
+        return token
+    except Exception as e:
+        _log(f"[sitecategory] Failed to obtain session token: {e}")
+        return None
+
+
+def get_sitecategory_category(domain, token):
+    """Get the URL category for a domain using the sitecategory.com API.
+
+    Returns the category string (e.g. 'Search Engines and Portals') or
+    'Unknown' if the category cannot be determined. Never raises.
+    """
+    if not token:
+        _log(f"  [get_sitecategory_category] No token available – using 'Unknown' for {domain}")
+        return "Unknown"
+    try:
+        _log(f"  [get_sitecategory_category] Looking up category for {domain}")
+        response = core_modules.requests.post(
+            SITECATEGORY_CATEGORIZE_URL,
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {token}",
+            },
+            json={"domain": domain},
+            timeout=15,
+        )
         response.raise_for_status()
         data = response.json()
-        categories = data.get("category", [])
-        if categories:
-            result = ", ".join(categories)
-            _log(f"  [get_categorify_category] Category for {domain}: {result}")
-            return result
-        _log(f"  [get_categorify_category] No category returned for {domain} – using 'Unknown'")
+        category = data.get("category", "")
+        if category:
+            _log(f"  [get_sitecategory_category] Category for {domain}: {category}")
+            return category
+        _log(f"  [get_sitecategory_category] No category returned for {domain} – using 'Unknown'")
         return "Unknown"
     except Exception as e:
-        _log(f"  [get_categorify_category] Error fetching category for {domain}: {e}")
+        _log(f"  [get_sitecategory_category] Error fetching category for {domain}: {e}")
         return "Unknown"
 
 

--- a/scripts/scanner.py
+++ b/scripts/scanner.py
@@ -20,7 +20,7 @@ with open("json/banned_sites.json") as banned_sites:
 DATA_REPO_PATH = core_modules.os.environ.get("DATA_REPO_PATH", "../dusk-li-data")
 
 # Maximum number of URLs to process in a single run
-MAX_URLS_PER_RUN = 200
+MAX_URLS_PER_RUN = 100
 
 # Skip domains already scanned within this many days
 RESCAN_AFTER_DAYS = 90
@@ -106,16 +106,16 @@ def collect_all_urls():
 
 # ── Per-domain scan logic ─────────────────────────────────────────────────────
 
-def process_domain(url):
+def process_domain(url, sitecategory_token):
     """Scan a single URL and write a YAML file if it passes all checks."""
     domain = core_modules.urlparse(url).netloc
     scheme = core_modules.urlparse(url).scheme
 
     log(f"[{domain}] Starting scan...")
 
-    log(f"[{domain}] Fetching categorify.org categorisation...")
-    site_cats = core_functions.get_categorify_category(domain)
-    log(f"[{domain}] categorify.org category: {site_cats}")
+    log(f"[{domain}] Fetching sitecategory.com categorisation...")
+    site_cats = core_functions.get_sitecategory_category(domain, sitecategory_token)
+    log(f"[{domain}] sitecategory.com category: {site_cats}")
 
     if any(cat in banned_sites_data.get("categories", []) for cat in site_cats.split(", ")):
         log(f"[{domain}] Category '{site_cats}' is banned – skipping")
@@ -176,11 +176,14 @@ all_urls = collect_all_urls()
 num_domains = len(all_urls)
 log(f"Processing {num_domains} unique domains...")
 
+log("Fetching sitecategory.com session token...")
+sitecategory_token = core_functions.get_sitecategory_token()
+
 # Process domains in parallel; limit concurrency to avoid overwhelming resources
 MAX_WORKERS = 5
 
 with core_modules.concurrent.futures.ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
-    futures = {executor.submit(process_domain, url): url for url in all_urls}
+    futures = {executor.submit(process_domain, url, sitecategory_token): url for url in all_urls}
     for i, future in enumerate(core_modules.concurrent.futures.as_completed(futures), start=1):
         url = futures[future]
         domain = core_modules.urlparse(url).netloc


### PR DESCRIPTION
Follow-up to #7. categorify.org returns 403 from GitHub Actions IP ranges.

## Changes

**`scripts/core_functions.py`**
- Add `get_sitecategory_token()` — POSTs to `https://api.sitecategory.com/api/session` to get a Bearer token (called once per run)
- Add `get_sitecategory_category(domain, token)` — POSTs to `https://api.sitecategory.com/api/categorize`; returns category string or `'Unknown'`

**`scripts/scanner.py`**
- Fetch session token once before the worker pool and pass it into each `process_domain` call
- Reduce `MAX_URLS_PER_RUN` from 200 → 100 to match the free-tier limit (100 req/day)