### PR TITLE
Remove site categorisation feature

### DIFF
--- a/scripts/core_functions.py
+++ b/scripts/core_functions.py
@@ -1,64 +1,8 @@
 import core_modules
 
-SITECATEGORY_SESSION_URL = "https://api.sitecategory.com/api/session"
-SITECATEGORY_CATEGORIZE_URL = "https://api.sitecategory.com/api/categorize"
-
 
 def _log(msg):
     print(msg, flush=True)
-
-
-def get_sitecategory_token():
-    """Obtain a session token from the sitecategory.com API.
-
-    Returns the token string, or None on failure.
-    """
-    try:
-        response = core_modules.requests.post(
-            SITECATEGORY_SESSION_URL,
-            headers={"Content-Type": "application/json"},
-            timeout=15,
-        )
-        response.raise_for_status()
-        token = response.json().get("token")
-        _log(f"[sitecategory] Session token obtained")
-        return token
-    except Exception as e:
-        _log(f"[sitecategory] Failed to obtain session token: {e}")
-        return None
-
-
-def get_sitecategory_category(domain, token):
-    """Get the URL category for a domain using the sitecategory.com API.
-
-    Returns the category string (e.g. 'Search Engines and Portals') or
-    'Unknown' if the category cannot be determined. Never raises.
-    """
-    if not token:
-        _log(f"  [get_sitecategory_category] No token available – using 'Unknown' for {domain}")
-        return "Unknown"
-    try:
-        _log(f"  [get_sitecategory_category] Looking up category for {domain}")
-        response = core_modules.requests.post(
-            SITECATEGORY_CATEGORIZE_URL,
-            headers={
-                "Content-Type": "application/json",
-                "Authorization": f"Bearer {token}",
-            },
-            json={"domain": domain},
-            timeout=15,
-        )
-        response.raise_for_status()
-        data = response.json()
-        category = data.get("category", "")
-        if category:
-            _log(f"  [get_sitecategory_category] Category for {domain}: {category}")
-            return category
-        _log(f"  [get_sitecategory_category] No category returned for {domain} – using 'Unknown'")
-        return "Unknown"
-    except Exception as e:
-        _log(f"  [get_sitecategory_category] Error fetching category for {domain}: {e}")
-        return "Unknown"
 
 
 def check_contrast(url):

--- a/scripts/scanner.py
+++ b/scripts/scanner.py
@@ -12,10 +12,6 @@ today = core_modules.date.today().isoformat()
 
 log(f"Scanner started on {today}")
 
-# Read the banned_sites JSON file
-with open("json/banned_sites.json") as banned_sites:
-    banned_sites_data = core_modules.json.load(banned_sites)
-
 # Path to the checked-out data repository (set by the workflow)
 DATA_REPO_PATH = core_modules.os.environ.get("DATA_REPO_PATH", "../dusk-li-data")
 
@@ -106,20 +102,12 @@ def collect_all_urls():
 
 # ── Per-domain scan logic ─────────────────────────────────────────────────────
 
-def process_domain(url, sitecategory_token):
+def process_domain(url):
     """Scan a single URL and write a YAML file if it passes all checks."""
     domain = core_modules.urlparse(url).netloc
     scheme = core_modules.urlparse(url).scheme
 
     log(f"[{domain}] Starting scan...")
-
-    log(f"[{domain}] Fetching sitecategory.com categorisation...")
-    site_cats = core_functions.get_sitecategory_category(domain, sitecategory_token)
-    log(f"[{domain}] sitecategory.com category: {site_cats}")
-
-    if any(cat in banned_sites_data.get("categories", []) for cat in site_cats.split(", ")):
-        log(f"[{domain}] Category '{site_cats}' is banned – skipping")
-        return
 
     log(f"[{domain}] Running contrast check...")
     contrast = core_functions.check_contrast(url)
@@ -156,7 +144,6 @@ def process_domain(url, sitecategory_token):
 
     yaml_string = (
         f"---\n"
-        f"category: {site_cats}\n"
         f"url: {scheme}://{domain}\n"
         f"dark_mode: {dark_mode}\n"
         f"contrast_accessibility: {contrast}\n"
@@ -168,7 +155,7 @@ def process_domain(url, sitecategory_token):
     with open(output_file, "w") as yaml_file:
         yaml_file.write(yaml_string)
 
-    log(f"[{domain}] Saved '{output_file}' (category: {site_cats}, dark_mode: {dark_mode}, score: {site_score}/3)")
+    log(f"[{domain}] Saved '{output_file}' (dark_mode: {dark_mode}, score: {site_score}/3)")
 
 # ── Main ──────────────────────────────────────────────────────────────────────
 
@@ -176,14 +163,11 @@ all_urls = collect_all_urls()
 num_domains = len(all_urls)
 log(f"Processing {num_domains} unique domains...")
 
-log("Fetching sitecategory.com session token...")
-sitecategory_token = core_functions.get_sitecategory_token()
-
 # Process domains in parallel; limit concurrency to avoid overwhelming resources
 MAX_WORKERS = 5
 
 with core_modules.concurrent.futures.ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
-    futures = {executor.submit(process_domain, url, sitecategory_token): url for url in all_urls}
+    futures = {executor.submit(process_domain, url): url for url in all_urls}
     for i, future in enumerate(core_modules.concurrent.futures.as_completed(futures), start=1):
         url = futures[future]
         domain = core_modules.urlparse(url).netloc


### PR DESCRIPTION
Category lookups (FortiGuard, categorify.org, sitecategory.com) all 403 from GitHub Actions IP ranges. Removing entirely.

- \core_functions.py\: remove \get_sitecategory_token\ and \get_sitecategory_category\
- \scanner.py\: remove banned_sites load, token fetch, category check, and \category\ field from YAML output