### PR TITLE
Fix hostname consistency, injection vector, add cirriustech.co.uk

### DIFF
--- a/.github/workflows/on-review-request.yml
+++ b/.github/workflows/on-review-request.yml
@@ -53,7 +53,7 @@ jobs:
         env:
           SCAN_URL: ${{ steps.extract.outputs.url }}
         run: |
-          DOMAIN=$(URL="${{ steps.extract.outputs.url }}" python3 -c "from urllib.parse import urlparse; import os; print(urlparse(os.environ['URL']).netloc)")
+          DOMAIN=$(python3 -c "from urllib.parse import urlparse; import os; print(urlparse(os.environ['SCAN_URL']).hostname)")
           YAML_URL="https://raw.githubusercontent.com/dusk-li/dusk-li-data/main/websites/${DOMAIN}.yaml"
           HTTP_STATUS=$(curl -s -o /tmp/existing.yaml -w "%{http_code}" "$YAML_URL")
           if [ "$HTTP_STATUS" = "200" ]; then

--- a/scripts/input/input.txt
+++ b/scripts/input/input.txt
@@ -23,3 +23,4 @@ https://scifistories.com/
 https://scoupy.com/
 https://stackmail.com/
 https://quickmovetech.com/
+https://cirriustech.co.uk/

--- a/scripts/scanner.py
+++ b/scripts/scanner.py
@@ -78,7 +78,7 @@ def collect_all_urls():
         if not core_modules.validators.url(url):
             invalid += 1
             continue
-        domain = core_modules.urlparse(url).netloc
+        domain = core_modules.urlparse(url).hostname
         if not domain or domain in seen_domains:
             duplicates += 1
             continue
@@ -99,8 +99,9 @@ def collect_all_urls():
 
 def process_domain(url):
     """Scan a single URL and write a YAML file if it passes all checks."""
-    domain = core_modules.urlparse(url).netloc
-    scheme = core_modules.urlparse(url).scheme
+    parsed = core_modules.urlparse(url)
+    domain = parsed.hostname  # hostname only (no port) — matches YAML filenames
+    scheme = parsed.scheme
 
     log(f"[{domain}] Starting scan...")
 


### PR DESCRIPTION
Fixes #14, #16, #17, #12

- **#16/#17**: Use \.hostname\ (not \.netloc\) everywhere — cooldown step and both spots in scanner.py — so YAML filenames are always \hostname.yaml\ with no embedded ports
- **#14**: Cooldown DOMAIN derived safely via env var (already in \), not via inline expression
- **#12**: Add cirriustech.co.uk to input.txt