### PR TITLE
Fix workflow trigger: detect template via body, apply label programmatically

### DIFF
--- a/.github/workflows/on-review-request.yml
+++ b/.github/workflows/on-review-request.yml
@@ -2,17 +2,30 @@ name: On Review Request
 
 on:
   issues:
-    types: [labeled]
+    types: [opened]
 
 jobs:
   handle:
-    if: github.event.label.name == 'review-request'
+    # Only process issues submitted via the review-request template.
+    # Detected by the presence of the "Website URL" heading from the form.
+    if: contains(github.event.issue.body, '### Website URL')
     runs-on: ubuntu-latest
     permissions:
       issues: write
       contents: read
 
     steps:
+      - name: Apply review-request label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['review-request']
+            });
+
       - name: Extract URL from issue body
         id: extract
         env:


### PR DESCRIPTION
GitHub only auto-applies labels from issue templates for users with write access — external contributors never triggered the workflow.

Fix: trigger on \issues: [opened]\, detect the review-request template by checking for \### Website URL\ in the body, and apply the label as the first step.